### PR TITLE
[HULK-388] Make django_two_factor compatible with django3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if sys.version_info >= (3,):
 
 setup(
     name='django-two-factor-auth',
-    version='0.3.4.cb.13',
+    version='0.3.4.cb.14',
     author='Bouke Haarsma',
     author_email='bouke@webatoom.nl',
     packages=find_packages(exclude=('demo', 'tests',)),

--- a/setup.py
+++ b/setup.py
@@ -4,33 +4,40 @@ import sys
 
 extra = {}
 if sys.version_info >= (3,):
-    extra['use_2to3'] = True
+    extra["use_2to3"] = True
 
 setup(
-    name='django-two-factor-auth',
-    version='0.3.4.cb.14',
-    author='Bouke Haarsma',
-    author_email='bouke@webatoom.nl',
-    packages=find_packages(exclude=('demo', 'tests',)),
-    package_data={'two_factor': ['templates/two_factor/*.html', ], },
-    url='http://github.com/chartbeat/django-two-factor-auth',
-    description='Complete Two-Factor Authentication for Django',
-    license='MIT',
-    long_description=open('README.rst').read(),
-    install_requires=[
-        'oath == 1.4.3'
-    ],
+    name="django-two-factor-auth",
+    version="0.3.4.cb.14",
+    author="Bouke Haarsma",
+    author_email="bouke@webatoom.nl",
+    packages=find_packages(
+        exclude=(
+            "demo",
+            "tests",
+        )
+    ),
+    package_data={
+        "two_factor": [
+            "templates/two_factor/*.html",
+        ],
+    },
+    url="http://github.com/chartbeat/django-two-factor-auth",
+    description="Complete Two-Factor Authentication for Django",
+    license="MIT",
+    long_description=open("README.rst").read(),
+    install_requires=["oath == 1.4.3"],
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Environment :: Web Environment',
-        'Framework :: Django',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Topic :: Security',
-        'Topic :: System :: Systems Administration :: Authentication/Directory',
+        "Development Status :: 2 - Pre-Alpha",
+        "Environment :: Web Environment",
+        "Framework :: Django",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Topic :: Security",
+        "Topic :: System :: Systems Administration :: Authentication/Directory",
     ],
     **extra
 )

--- a/two_factor/auth_backends.py
+++ b/two_factor/auth_backends.py
@@ -3,15 +3,18 @@ from django.utils.timezone import now
 from oath import accept_totp
 from django.conf import settings
 
-TF_FORWARD_DRIFT = getattr(settings,'TF_FORWARD_DRIFT', 1)
-TF_BACKWARD_DRIFT = getattr(settings,'TF_BACKWARD_DRIFT', 1)
+TF_FORWARD_DRIFT = getattr(settings, "TF_FORWARD_DRIFT", 1)
+TF_BACKWARD_DRIFT = getattr(settings, "TF_BACKWARD_DRIFT", 1)
 
 
 class TokenBackend(ModelBackend):
     def authenticate(self, request, user, token):
-        accepted, drift = accept_totp(key=user.tf_token.seed, response=token,
-                                      forward_drift=TF_FORWARD_DRIFT,
-                                      backward_drift=TF_BACKWARD_DRIFT)
+        accepted, drift = accept_totp(
+            key=user.tf_token.seed,
+            response=token,
+            forward_drift=TF_FORWARD_DRIFT,
+            backward_drift=TF_BACKWARD_DRIFT,
+        )
         return user if accepted else None
 
 

--- a/two_factor/auth_backends.py
+++ b/two_factor/auth_backends.py
@@ -8,7 +8,7 @@ TF_BACKWARD_DRIFT = getattr(settings,'TF_BACKWARD_DRIFT', 1)
 
 
 class TokenBackend(ModelBackend):
-    def authenticate(self, user, token):
+    def authenticate(self, request, user, token):
         accepted, drift = accept_totp(key=user.tf_token.seed, response=token,
                                       forward_drift=TF_FORWARD_DRIFT,
                                       backward_drift=TF_BACKWARD_DRIFT)
@@ -16,7 +16,7 @@ class TokenBackend(ModelBackend):
 
 
 class VerifiedComputerBackend(ModelBackend):
-    def authenticate(self, user, computer_id):
+    def authenticate(self, request, user, computer_id):
         verification = user.tf_verified_computers.get(pk=computer_id)
         if verification.verified_until < now():
             return None


### PR DESCRIPTION
Backend authentication in Django3 requires an additional request parameter in authenticate() function definitions:
https://docs.djangoproject.com/en/3.1/topics/auth/default/#django.contrib.auth.authenticate